### PR TITLE
New overload of RedeployableScriptSupportIsEnabled that accepts comma…

### DIFF
--- a/src/dbup-core/Support/TableJournal.cs
+++ b/src/dbup-core/Support/TableJournal.cs
@@ -177,7 +177,7 @@ namespace DbUp.Support
         protected IDbCommand GetJournalEntriesCommand(Func<IDbCommand> dbCommandFactory)
         {
             var command = dbCommandFactory();
-            command.CommandText = GetJournalEntriesSql();
+            command.CommandText = GetJournalEntriesSql(dbCommandFactory) ?? GetJournalEntriesSql();
             command.CommandType = CommandType.Text;
             return command;
         }
@@ -214,6 +214,11 @@ namespace DbUp.Support
         /// Sql for getting the journal entries
         /// </summary>
         protected abstract string GetJournalEntriesSql();
+
+        protected virtual string GetJournalEntriesSql(Func<IDbCommand> dbCommandFactory)
+        {
+            return null;
+        }
 
         /// <summary>
         /// Sql for creating journal table
@@ -304,6 +309,22 @@ namespace DbUp.Support
                     return false;
                 }
             });
+        }
+
+        /// <summary>
+        /// Returns whether redeployable script support is enabled before starting applying changes
+        /// </summary>
+        public bool RedeployableScriptSupportIsEnabled(Func<IDbCommand> dbCommandFactory)
+        {
+            try
+            {
+                IDbCommand dbCommand = dbCommandFactory();
+                return VerifyColumnExistsCommand(dbCommand, UnquotedSchemaTableName, "Hash", SchemaTableSchema);
+            }
+            catch (DbException)
+            {
+                return false;
+            }
         }
 
         /// <summary>Verify, using database-specific queries, if the table exists in the database.</summary>

--- a/src/dbup-sqlserver/SqlTableJournal.cs
+++ b/src/dbup-sqlserver/SqlTableJournal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data;
 using DbUp.Engine;
 using DbUp.Engine.Output;
 using DbUp.Engine.Transactions;
@@ -42,7 +43,12 @@ namespace DbUp.SqlServer
 
         protected override string GetJournalEntriesSql()
         {
-            if (RedeployableScriptSupportIsEnabled())
+            throw new NotImplementedException();
+        }
+
+        protected override string GetJournalEntriesSql(Func<IDbCommand> dbCommandFactory)
+        {
+            if (RedeployableScriptSupportIsEnabled(dbCommandFactory))
             {
                 // if redeployable script support is enabled, use Hash column value;
                 // because redeployable script can appear multiple times with different Hash value, retrieve the most recent redeploy record


### PR DESCRIPTION
New overload of RedeployableScriptSupportIsEnabled that accepts command factory in parameter, to execute command that it needs in same "global" transaction and to avoid "SqlConnection does not support parallel transactions" exception.

When I configure UpgradeBuilder with "WithTrransactionPerScript()", exception written above is raised immediately after start, before any migration scripts are executed.
The problem doesn't exist in the original DbUp tool.